### PR TITLE
Fix memory leaks

### DIFF
--- a/sources/client.cpp
+++ b/sources/client.cpp
@@ -458,7 +458,9 @@ namespace WebDAV
     {
       pugi::xml_node href = response.node().select_node("*[local-name()='href']").node();
       std::string encode_file_name = href.first_child().value();
-      std::string resource_path = curl_unescape(encode_file_name.c_str(), static_cast<int>(encode_file_name.length()));
+      char* unescaped = curl_unescape(encode_file_name.c_str(), static_cast<int>(encode_file_name.length())); //this allocates new memory
+      std::string resource_path{unescaped}; // the data is copied
+      free(unescaped);
       auto target_path = target_urn.path();
       auto target_path_without_sep = target_urn.path();
       if (!target_path_without_sep.empty() && target_path_without_sep.back() == '/')

--- a/sources/client.cpp
+++ b/sources/client.cpp
@@ -460,7 +460,7 @@ namespace WebDAV
       std::string encode_file_name = href.first_child().value();
       char* unescaped = curl_unescape(encode_file_name.c_str(), static_cast<int>(encode_file_name.length())); //this allocates new memory
       std::string resource_path{unescaped}; // the data is copied
-      free(unescaped);
+      curl_free(unescaped);
       auto target_path = target_urn.path();
       auto target_path_without_sep = target_urn.path();
       if (!target_path_without_sep.empty() && target_path_without_sep.back() == '/')

--- a/sources/urn.cpp
+++ b/sources/urn.cpp
@@ -81,7 +81,9 @@ namespace WebDAV
 
     auto escape(void* request, const string& name) -> string
     {
-      string path = curl_easy_escape(request, name.c_str(), static_cast<int>(name.length()));
+      char * escaped = curl_easy_escape(request, name.c_str(), static_cast<int>(name.length())); // allocates new string
+      string path{escaped}; // this copies the string
+      free(escaped);
       return path;
     }
 

--- a/sources/urn.cpp
+++ b/sources/urn.cpp
@@ -81,9 +81,9 @@ namespace WebDAV
 
     auto escape(void* request, const string& name) -> string
     {
-      char * escaped = curl_easy_escape(request, name.c_str(), static_cast<int>(name.length())); // allocates new string
-      string path{escaped}; // this copies the string
-      free(escaped);
+      char * escaped = curl_easy_escape(request, name.c_str(), static_cast<int>(name.length())); // allocates new memory
+      string path{escaped}; // this copies the data
+      free(escaped); // must free the memory
       return path;
     }
 

--- a/sources/urn.cpp
+++ b/sources/urn.cpp
@@ -83,7 +83,7 @@ namespace WebDAV
     {
       char * escaped = curl_easy_escape(request, name.c_str(), static_cast<int>(name.length())); // allocates new memory
       string path{escaped}; // this copies the data
-      free(escaped); // must free the memory
+      curl_free(escaped); // must free the memory
       return path;
     }
 


### PR DESCRIPTION
curl_easy_escape() and curl_unescape() allocate new memory for the char*. std::string constructor copies the data from char*, and the char* needs to be freed afterwards, which it was not and therefore it was leaking.

Also, Is there a reason for using curl_unescape() instead of curl_easy_unescape()?